### PR TITLE
feat: add fullWidth prop

### DIFF
--- a/src/components/Input/Button/index.stories.tsx
+++ b/src/components/Input/Button/index.stories.tsx
@@ -14,15 +14,14 @@ export default {
   ],
 } as Meta<typeof Button>;
 
-const Template: Story<ButtonProps> = (args) => (
-  <Button {...args} style={{ width: '100%' }} />
-);
+const Template: Story<ButtonProps> = (args) => <Button {...args} />;
 
 export const Contained = Template.bind({});
 Contained.args = {
   buttonType: 'contained',
   color: 'red',
   children: '완료',
+  fullWidth: true,
 };
 
 export const Outline = Template.bind({});
@@ -31,4 +30,5 @@ Outline.args = {
   color: 'green',
   rounded: true,
   children: '매워서 못 먹어요',
+  fullWidth: true,
 };

--- a/src/components/Input/Button/index.tsx
+++ b/src/components/Input/Button/index.tsx
@@ -5,7 +5,8 @@ import { HTMLAttributes } from 'markdown-to-jsx/node_modules/@types/react';
 export interface ButtonProps extends HTMLAttributes<HTMLButtonElement> {
   buttonType: 'contained' | 'outline';
   color: 'green' | 'red' | 'grey';
-  rounded: boolean;
+  rounded?: boolean;
+  fullWidth?: boolean;
   children?: React.ReactNode;
 }
 
@@ -28,6 +29,7 @@ const StyledButton = styled.button<ButtonProps>`
   border: none;
   outline: none;
   cursor: pointer;
+  width: ${({ fullWidth = false }) => (fullWidth ? '100%' : 'auto')};
 
   ${({ buttonType, color, theme }) =>
     buttonType === 'contained' &&
@@ -35,7 +37,6 @@ const StyledButton = styled.button<ButtonProps>`
       color: ${color === 'green' ? theme.colors.black : theme.colors.white};
       background: ${getColor(color, theme)};
     `}
-
   ${({ buttonType, color, theme }) =>
     buttonType === 'outline' &&
     css`
@@ -45,12 +46,11 @@ const StyledButton = styled.button<ButtonProps>`
         background-color: ${getColor(color, theme)};
       }
     `}
-
-    ${({ rounded }) =>
+    ${({ rounded = false }) =>
     rounded &&
     css`
       border-radius: 100px;
-    `}
+    `};
 `;
 
 const getColor = (color: string, theme: Theme) => {


### PR DESCRIPTION
## 📌 제목
> 버튼 컴포넌트의 width: 100%를 prop 으로 적용하는 기능 추가

## 📌 작업 내용 

- 이제 버튼 컴포넌트에 fullWidth prop을 전달하면 width:100% 가 적용됩니다.
- 스토리북 코드도 관련해서 수정했습니다.
- 더불어서 rounded도 false를 기본으로 해서 true로 원할때만 prop으로 전달하면 되도록 수정했습니다. 

## 📌 기타
> 혹시 놓친 점 있으면 알려주세요! 

#12 
