### PR TITLE
feat: add integrating user count api

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -9,3 +9,9 @@ export const apiClient = axios.create({
     'Content-Type': 'application/json',
   },
 });
+
+export type Response<T> = {
+  data: T;
+  statusCode: number;
+  message: string;
+};

--- a/src/api/user/index.tsx
+++ b/src/api/user/index.tsx
@@ -1,16 +1,12 @@
-import { apiClient } from '@/api';
+import { apiClient, Response } from '@/api';
 
 export const anonymousUserIdKey = 'ohmebddeng-anonymous-user-id';
 export const userIdKey = 'ohmebddeng-user-id';
 
-export interface AnonymousUser {
-  data: {
-    anonymousId: string;
-    userId: string;
-  };
-  statusCode: number;
-  message: string;
-}
+export type AnonymousUser = Response<{
+  anonymousId: string;
+  userId: string;
+}>;
 
 export const getAnonymousUserQuery = async () => {
   try {
@@ -56,3 +52,17 @@ export interface User {
   statusCode: number;
   message: string;
 }
+
+export type UserCount = { count: number; levelTestedOnly: boolean };
+
+export const getUserCount = async () => {
+  const {
+    data: { data },
+  } = await apiClient.get<Response<UserCount>>(`/user/count`, {
+    params: {
+      levelTestedOnly: false,
+    },
+  });
+
+  return data;
+};

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,15 +1,27 @@
 import { css, useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
-import type { NextPage } from 'next';
+import type { InferGetServerSidePropsType } from 'next';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
 import React, { useCallback } from 'react';
+import { useQuery } from 'react-query';
+import { getUserCount, UserCount } from '@/api/user';
 import Button from '@/components/Input/Button';
 import { ROUTES } from '@/constants';
 import logo from '@public/images/logo.png';
 import userLevel5 from '@public/images/user-level-5.png';
 
-const Home: NextPage = () => {
+export const getServerSideProps = async () => {
+  const userCount = await getUserCount();
+
+  return {
+    props: { userCount },
+  };
+};
+
+const Home = ({
+  userCount,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) => {
   const router = useRouter();
   const theme = useTheme();
 
@@ -21,7 +33,9 @@ const Home: NextPage = () => {
     router.push(ROUTES.MAIN);
   }, [router]);
 
-  // TODO: fetch user count info
+  const { data } = useQuery<UserCount>('getUserCount', getUserCount, {
+    initialData: userCount,
+  });
 
   return (
     <Container>
@@ -52,7 +66,7 @@ const Home: NextPage = () => {
           당신에게 맞는 매운 음식,,추천해줄게,,
         </p>
 
-        <SpeachBubble>N명 참여중!</SpeachBubble>
+        <SpeachBubble>{data?.count}명 참여중!</SpeachBubble>
       </div>
 
       <div


### PR DESCRIPTION
## 📌 제목

테스트 참여 사용자 수 API 연동

## 📌 작업 내용

- 홈페이지에서 참여자 수를 SSR해서 보여주도록 하였습니다
- API 응답 구조에 공통된 부분(data, status, message)을 상속하여 typing 하는 base type을 추가했습니다


